### PR TITLE
ECSAPP-114281 Replace Chargebee and Stripe APIs keys with placeholders

### DIFF
--- a/java/webapp/chargebee_js/signup.html
+++ b/java/webapp/chargebee_js/signup.html
@@ -21,7 +21,7 @@
                 errorElement: "small"
             });
 
-            ChargeBee.configure({site: 'honeycomics-test', api_key: "test_gML2sWuB7Z6qbrrVZ0B1Aq6xjEwxaqZo"});
+            ChargeBee.configure({site: 'honeycomics-test', api_key: "your-chargebee-api-key"});
 
             
             function subscribeErrorHandler(response) {

--- a/java/webapp/stripe-popup-js/signup.html
+++ b/java/webapp/stripe-popup-js/signup.html
@@ -94,7 +94,7 @@
                 // configuring Stripe publishable key and setting the options in Stripe Js.
                 var handler = StripeCheckout.configure({
                     //Replace it with your stripe publishable key
-                    key: 'pk_test_acfVSJh9Oo9QIGTAQpUvG5Ig',
+                    key: 'your-stripe-publishable-key',
                     image: '/assets/images/favicon.png',
                     allowRememberMe: false,
                     token: handleStripeToken

--- a/php/chargebee_js/signup.html
+++ b/php/chargebee_js/signup.html
@@ -21,7 +21,7 @@
                 errorElement: "small"
             });
 
-            ChargeBee.configure({site: 'honeycomics-test', api_key: "test_gML2sWuB7Z6qbrrVZ0B1Aq6xjEwxaqZo"});
+            ChargeBee.configure({site: 'honeycomics-test', api_key: "your-chargebee-api-key"});
 
             
             function subscribeErrorHandler(response) {

--- a/php/stripe-popup-js/signup.html
+++ b/php/stripe-popup-js/signup.html
@@ -94,7 +94,7 @@
                 // configuring Stripe publishable key and setting the options in Stripe Js.
                 var handler = StripeCheckout.configure({
                     //Replace it with your stripe publishable key
-                    key: 'pk_test_acfVSJh9Oo9QIGTAQpUvG5Ig',
+                    key: 'your-stripe-publishable-key',
                     image: '/assets/images/favicon.png',
                     allowRememberMe: false,
                     token: handleStripeToken

--- a/ruby/cb_sample_apps/public/chargebee_js/signup.html
+++ b/ruby/cb_sample_apps/public/chargebee_js/signup.html
@@ -21,7 +21,7 @@
                 errorElement: "small"
             });
 
-            ChargeBee.configure({site: 'honeycomics-test', api_key: "test_gML2sWuB7Z6qbrrVZ0B1Aq6xjEwxaqZo"});
+            ChargeBee.configure({site: 'honeycomics-test', api_key: "your-chargebee-api-key"});
 
             
             function subscribeErrorHandler(response) {

--- a/ruby/cb_sample_apps/public/stripe-popup-js/signup.html
+++ b/ruby/cb_sample_apps/public/stripe-popup-js/signup.html
@@ -94,7 +94,7 @@
                 // configuring Stripe publishable key and setting the options in Stripe Js.
                 var handler = StripeCheckout.configure({
                     //Replace it with your stripe publishable key
-                    key: 'pk_test_acfVSJh9Oo9QIGTAQpUvG5Ig',
+                    key: 'your-stripe-publishable-key',
                     image: '/assets/images/favicon.png',
                     allowRememberMe: false,
                     token: handleStripeToken


### PR DESCRIPTION
https://mychargebee.atlassian.net/browse/ECSAPP-114281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Replaced embedded ChargeBee and Stripe test API keys with placeholders in Java, PHP, and Ruby sample signup pages. Preserved the configured ChargeBee sites and Stripe Checkout configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->