### PR TITLE
PAYCOMP-373 Fix address state code and payment intent fetch headers

### DIFF
--- a/payment-components/vanilla-js/apps/client/scripts/checkout.js
+++ b/payment-components/vanilla-js/apps/client/scripts/checkout.js
@@ -192,7 +192,7 @@ function setPaymentComponentOptions(index) {
                             "phone": "634-067-4573",
                             "addressLine1": "Arster Hemm 59",
                             "city": "Bremen",
-                            "stateCode": "ON",
+                            "stateCode": "HB",
                             "countryCode": "DE", // Advanced Routing variable.
                             "zip": "28279"
                         },
@@ -202,7 +202,7 @@ function setPaymentComponentOptions(index) {
                             "phone": "634-067-4573",
                             "addressLine1": "Arster Hemm 59",
                             "city": "Bremen",
-                            "stateCode": "ON",
+                            "stateCode": "HB",
                             "countryCode": "DE", // Advanced Routing variable.
                             "zip": "28279"
                           }
@@ -239,10 +239,7 @@ async function getPaymentIntent(paymentIntentId){
     try{
         const url = `http://localhost:8082/payment-intent/${paymentIntentId}`;
         const response = await fetch(url, {
-            method: "GET",
-            headers: {
-                "Content_Type": "application/json"
-            }
+            method: "GET"
         });
 
         if(!response.ok) {


### PR DESCRIPTION
## Summary

Two fixes to the vanilla-js Payment Components sample, raised by CodeRabbit while reviewing the tutorial migration in [chargebee-tutorials#452](https://github.com/chargebee/chargebee-tutorials/pull/452).

- The Bremen billing and shipping addresses used `stateCode: "ON"` (Ontario, Canada) alongside `countryCode: "DE"`. Corrected to `HB`, the ISO 3166-2:DE code for Bremen. This matters here because the country code is the Advanced Routing variable the sample demonstrates.
- Dropped the `headers` block from the payment intent `GET`. The key was misspelled `Content_Type`, and a content type header has no meaning on a request without a body.

## Test plan

- [ ] Run the sample app and confirm the payment intent is retrieved successfully.
- [ ] Confirm the German address still routes to the expected gateway under Advanced Routing.

Made with [Cursor](https://cursor.com)